### PR TITLE
Fix random index picking

### DIFF
--- a/src/main/java/dev/strubbelkopp/bundle_jumble/mixin/BundleItemMixin.java
+++ b/src/main/java/dev/strubbelkopp/bundle_jumble/mixin/BundleItemMixin.java
@@ -57,7 +57,7 @@ public abstract class BundleItemMixin extends Item {
             Random random = world.getRandom();
             random.setSeed(bundleItemStack.getOrDefault(BundleJumble.RANDOM_SEED, random.nextLong()));
             bundleItemStack.set(BundleJumble.RANDOM_SEED, random.nextLong());
-            int randomIndex = random.nextInt(availableIndexes.size());
+            int randomIndex = availableIndexes.get(random.nextInt(availableIndexes.size()));
             BlockItem blockItem = (BlockItem) bundleContentsComponent.get(randomIndex).getItem();
 
             result = blockItem.useOnBlock(context);


### PR DESCRIPTION
Before, it was choosing an index between 0 and `availableIndexes`' size. This index isn't necessarily one of `availableIndexes`.

Now, it's choosing one of the indexes that's in the `availableIndexes` list.

Btw I made a port for neoforge here: https://github.com/adil192/BundleDirect. If you have any concerns about licensing, credits, or anything else, please let me know!